### PR TITLE
Atr circle table

### DIFF
--- a/sonde_stats.py
+++ b/sonde_stats.py
@@ -103,60 +103,63 @@ df.to_latex(
     label="tab:sonde_stats",
 )
 # %%
-entries = []
-for key in meta["HALO"].keys():
-    for entry in meta["HALO"][key]["segments"]:
+atr_circle_segments = []
+for halo_flight in meta["HALO"].keys():
+    for entry in meta["HALO"][halo_flight]["segments"]:
         if ("atr_coordination" in entry["kinds"]) and ("circle" in entry["kinds"]):
             print(entry["segment_id"], entry["start"], entry["end"])
-            entries.append(entry)
+            atr_circle_segments.append(entry)
             print(entry["kinds"])
 
 # %%
-
-
-def get_atr_info(entry):
-    start = entry["start"]
-    end = entry["end"]
-    id = entry["segment_id"]
-    min_diff_to_atr_start = np.min(
-        [np.abs(meta["ATR"][key]["takeoff"] - end) for key in meta["ATR"].keys()]
-    )
-    min_diff_to_atr_end = np.min(
-        [np.abs(start - meta["ATR"][key]["landing"]) for key in meta["ATR"].keys()]
-    )
+def atr_flight_for_circle(circle):
+    potential_flights = []
     for key in meta["ATR"].keys():
-        atr_start = meta["ATR"][key]["takeoff"]
-        atr_end = meta["ATR"][key]["landing"]
+        flight = meta["ATR"][key]
+        if circle["start"].date() == flight["date"]:
+            potential_flights.append(flight)
+            #print(flight["flight_id"], flight["takeoff"], flight["landing"])
+    if len(potential_flights) == 0:
+        print("No ATR flight found for circle", circle["segment_id"])
+        return None
+    elif len(potential_flights) == 1:
+        return potential_flights[0]
+    elif len(potential_flights) > 1:
+        circle_ref_time = circle["start"] + (circle["end"] - circle["start"]) / 2
+        flight_ref_time = [flight["takeoff"] + (flight["landing"] - flight["takeoff"]) / 2 for flight in potential_flights]
+        flight_ind = np.argmin([np.abs(circle_ref_time - f) for f in flight_ref_time])
+        return potential_flights[flight_ind]
 
-        start_diff = np.abs(start - atr_end)
-        end_diff = np.abs(atr_start - end)
-        if np.abs(start_diff - min_diff_to_atr_end) < timedelta(minutes=5) or (
-            np.abs(end_diff - min_diff_to_atr_start)
-        ) < timedelta(minutes=5):
-            # if ( timedelta(minutes=-6 * 60) < start_diff < timedelta(minutes=60)) or (timedelta(minutes=-6 * 60) < end_diff <timedelta(minutes=60)):
-            return {
-                "HALO circle ID": (id).replace("_", "\_"),
-                "ATR flight ID": key,
-                "ATR takeoff": atr_start,
-                "ATR landing": atr_end,
-                #                "HALO circle start": start,
-                #                "HALO circle end": end,
-                "Level 3 sondes": l3.where(
-                    (l3.sonde_time > np.datetime64(start))
-                    & (l3.sonde_time < np.datetime64(end)),
-                    drop=True,
-                ).sizes["sonde"],
-                "Level 4 sondes": l4.swap_dims({"circle": "circle_id"})
-                .sondes_per_circle.sel(circle_id=id)
-                .values,
-            }
-    return {}
+for circle in atr_circle_segments:
+    print(circle["segment_id"], circle["start"].strftime("%H:%M:%S"), circle["end"].strftime("%H:%M:%S"))
+    flight = atr_flight_for_circle(circle)
+    print(flight["flight_id"], flight["takeoff"].strftime("%H:%M:%S"), flight["landing"].strftime("%H:%M:%S"))
+    print("--------")
+
+# %%
+
+def get_atr_info(circle):
+    flight = atr_flight_for_circle(circle)
+    return {
+        "flight ID": flight["flight_id"],
+        "flight date": flight["date"],
+        "flight time": f"{flight['takeoff'].strftime('%H:%M:%S')}-{flight['landing'].strftime('%H:%M:%S')}",
+        "Level 3 sondes": l3.where(
+            (l3.sonde_time > np.datetime64(circle["start"]))
+            & (l3.sonde_time < np.datetime64(circle["end"])),
+            drop=True,
+        ).sizes["sonde"],
+        "Level 4 sondes": l4.swap_dims({"circle": "circle_id"})
+        .sondes_per_circle.sel(circle_id=circle["segment_id"])
+        .values,
+        "HALO circle ID": circle["segment_id"].replace("_", "\_"),
+    }
 
 
 # %%
-df = pd.DataFrame.from_records(map(get_atr_info, entries))
+df = pd.DataFrame.from_records(map(get_atr_info, atr_circle_segments))
 
-df.sort_values("HALO circle ID", inplace=True)
+df.sort_values("flight ID", inplace=True)
 # %%
 df.to_latex(
     "atr_stats.tex",

--- a/sonde_stats.py
+++ b/sonde_stats.py
@@ -58,8 +58,9 @@ def get_flight_info(flight_id):
 
     return {
         "flight ID": flight_id,
-        "takeoff": flight["takeoff"],
-        "landing": flight["landing"],
+        "date": flight["date"],
+        "flight time": str(flight["takeoff"].strftime("%H:%M:%S"))+"-"+str(flight["landing"].strftime("%H:%M:%S")),
+        #"landing": flight["landing"].strftime("%H:%M:%S"),
         "Level 0": len(
             [
                 fname
@@ -77,13 +78,14 @@ def get_flight_info(flight_id):
 
 # %%
 df = pd.DataFrame.from_records(map(get_flight_info, set(l3.flight_id.values)))
-df = df.sort_values("takeoff")
+df = df.sort_values("date")
 
 # %%
 total = {
     "flight ID": "Total",
-    "takeoff": "",
-    "landing": "",
+    "date": "",
+    "flight time": "",
+    #"landing": "",
     "Level 0": df["Level 0"].sum(),
     "Level 1": df["Level 1"].sum(),
     "Level 2": df["Level 2"].sum(),

--- a/sonde_stats.py
+++ b/sonde_stats.py
@@ -6,7 +6,6 @@ from orcestra import get_flight_segments
 import fsspec
 import re
 from plots import settings
-from datetime import timedelta
 
 
 meta = get_flight_segments()
@@ -59,8 +58,10 @@ def get_flight_info(flight_id):
     return {
         "flight ID": flight_id,
         "date": flight["date"],
-        "flight time": str(flight["takeoff"].strftime("%H:%M:%S"))+"-"+str(flight["landing"].strftime("%H:%M:%S")),
-        #"landing": flight["landing"].strftime("%H:%M:%S"),
+        "flight time": str(flight["takeoff"].strftime("%H:%M:%S"))
+        + "-"
+        + str(flight["landing"].strftime("%H:%M:%S")),
+        # "landing": flight["landing"].strftime("%H:%M:%S"),
         "Level 0": len(
             [
                 fname
@@ -85,7 +86,7 @@ total = {
     "flight ID": "Total",
     "date": "",
     "flight time": "",
-    #"landing": "",
+    # "landing": "",
     "Level 0": df["Level 0"].sum(),
     "Level 1": df["Level 1"].sum(),
     "Level 2": df["Level 2"].sum(),
@@ -111,6 +112,7 @@ for halo_flight in meta["HALO"].keys():
             atr_circle_segments.append(entry)
             print(entry["kinds"])
 
+
 # %%
 def atr_flight_for_circle(circle):
     potential_flights = []
@@ -118,7 +120,7 @@ def atr_flight_for_circle(circle):
         flight = meta["ATR"][key]
         if circle["start"].date() == flight["date"]:
             potential_flights.append(flight)
-            #print(flight["flight_id"], flight["takeoff"], flight["landing"])
+            # print(flight["flight_id"], flight["takeoff"], flight["landing"])
     if len(potential_flights) == 0:
         print("No ATR flight found for circle", circle["segment_id"])
         return None
@@ -126,17 +128,30 @@ def atr_flight_for_circle(circle):
         return potential_flights[0]
     elif len(potential_flights) > 1:
         circle_ref_time = circle["start"] + (circle["end"] - circle["start"]) / 2
-        flight_ref_time = [flight["takeoff"] + (flight["landing"] - flight["takeoff"]) / 2 for flight in potential_flights]
+        flight_ref_time = [
+            flight["takeoff"] + (flight["landing"] - flight["takeoff"]) / 2
+            for flight in potential_flights
+        ]
         flight_ind = np.argmin([np.abs(circle_ref_time - f) for f in flight_ref_time])
         return potential_flights[flight_ind]
 
+
 for circle in atr_circle_segments:
-    print(circle["segment_id"], circle["start"].strftime("%H:%M:%S"), circle["end"].strftime("%H:%M:%S"))
+    print(
+        circle["segment_id"],
+        circle["start"].strftime("%H:%M:%S"),
+        circle["end"].strftime("%H:%M:%S"),
+    )
     flight = atr_flight_for_circle(circle)
-    print(flight["flight_id"], flight["takeoff"].strftime("%H:%M:%S"), flight["landing"].strftime("%H:%M:%S"))
+    print(
+        flight["flight_id"],
+        flight["takeoff"].strftime("%H:%M:%S"),
+        flight["landing"].strftime("%H:%M:%S"),
+    )
     print("--------")
 
 # %%
+
 
 def get_atr_info(circle):
     flight = atr_flight_for_circle(circle)


### PR DESCRIPTION
The table of HALO circles tagged as "ATR coordination" had one bug for a flight on 08-22 which was a complicated case due to two HALO circles in "ATR coordination" happening on the same day and related to two different ATR flights. I couldn't get your way to handle this case and therefore suggest here a method that defines the closest flight by comparing a reference time (average of the time period) of respective circle and all flights happening on that day. This seems to work well for the cases that we have.

I also tried to simplify/shorten the date and time info in both tables, HALO and the separate and new ATR table. This was initiated by Bjorn manually changing the .tex table document for HALO to shorten the start and landing times.